### PR TITLE
updates for C-term

### DIFF
--- a/examples/Servo/Servo.ino
+++ b/examples/Servo/Servo.ino
@@ -1,0 +1,33 @@
+#include <RBE1001Lib.h>
+#include <ESP32Servo.h>
+#include <ESP32AnalogRead.h>
+
+// https://wpiroboticsengineering.github.io/RBE1001Lib/classServo.html
+Servo lifter;
+// https://wpiroboticsengineering.github.io/RBE1001Lib/classESP32AnalogRead.html
+ESP32AnalogRead servoPositionFeedback;
+
+
+void setup() 
+{
+	Serial.begin(115200);
+	ESP32PWM::allocateTimer(1); // Used by servos
+
+	// pin definitions https://wpiroboticsengineering.github.io/RBE1001Lib/RBE1001Lib_8h.html#define-members
+	lifter.attach(SERVO_PIN);
+	servoPositionFeedback.attach(SERVO_FEEDBACK_SENSOR);
+	lifter.write(0);
+}
+
+/*
+ * The main loop for the program. The loop function is repeatedly called
+ * once the ESP32 is started. 
+ */
+
+void loop() 
+{
+	uint16_t angle = (millis()/100) % 180;
+	lifter.write(angle);
+	Serial.println(angle);
+	delay(10);
+}

--- a/src/Motor.cpp
+++ b/src/Motor.cpp
@@ -321,6 +321,16 @@ void Motor::loop() {
 		//portEXIT_CRITICAL(&mmux);
 	}
 
+	else
+	{
+		if(targetEffort > currentEffort + DELTA_EFFORT)
+			currentEffort += DELTA_EFFORT;
+		else if(targetEffort < currentEffort - DELTA_EFFORT)
+			currentEffort -= DELTA_EFFORT;
+		else currentEffort = targetEffort;
+	}
+	
+
 	interruptCountForVelocity++;
 	if (interruptCountForVelocity == 50) {
 		interruptCountForVelocity = 0;
@@ -399,7 +409,7 @@ void Motor::setEffort(float effort) {
 		effort = -1;
 //portENTER_CRITICAL(&mmux);
 	closedLoopControl = false;
-	currentEffort = effort;
+	targetEffort = effort;
 //portEXIT_CRITICAL(&mmux);
 }
 /*

--- a/src/Motor.cpp
+++ b/src/Motor.cpp
@@ -243,6 +243,7 @@ void Motor::moveFor(float deltaTargetInDegrees, float speedDegPerSec) {
  * @param newDegreesPerSecond the new speed in degrees per second
  */
 void Motor::setSpeed(float newDegreesPerSecond) {
+	if(closedLoopControl == false) setSetpoint(getCurrentDegrees());
 	if (fabs(newDegreesPerSecond) < 0.1) {
 		setSetpoint(getCurrentDegrees());
 		//ESP_LOGI(TAG, "Stopping");

--- a/src/Motor.h
+++ b/src/Motor.h
@@ -16,6 +16,10 @@
 #define QUADRATUE_MULTIPLYER 1.0f
 #define TICKS_TO_DEGREES ((QUADRATUE_MULTIPLYER/(ENCODER_CPR*GEAR_BOX_RATIO/360.0))*-1)
 #define I_TERM_SIZE 120.0f
+
+
+const float DELTA_EFFORT = 0.0025;
+
 enum interpolateMode {
 	LINEAR_INTERPOLATION=1, SINUSOIDAL_INTERPOLATION=2, VELOCITY_MODE=3, BEZIER=4, TRAPEZOIDAL=5
 };
@@ -90,6 +94,10 @@ private:
 	 *
 	 */
 	bool closedLoopControl = true;
+	/**
+	 * variable for storing target effort to allow for smoother accelerations
+	 */
+	float targetEffort = 0;
 	/**
 	 * variable for caching the current effort being sent to the PWM/direction pins
 	 */

--- a/src/RBE1001Lib.h
+++ b/src/RBE1001Lib.h
@@ -57,9 +57,9 @@
 #define MOTOR_RIGHT_DIR 25
 //Encoder pins
 
-#define MOTOR_LEFT_ENCA 26
+#define MOTOR_LEFT_ENCA 27
 //A0
-#define MOTOR_LEFT_ENCB 27
+#define MOTOR_LEFT_ENCB 26
 
 
 #define MOTOR_RIGHT_ENCA 32

--- a/src/RBE1001Lib.h
+++ b/src/RBE1001Lib.h
@@ -21,8 +21,8 @@
 #define SPI_SS   5
 
 // Ultrasonics
-#define SIDE_ULTRASONIC_TRIG 23
-#define SIDE_ULTRASONIC_ECHO 22
+#define SIDE_ULTRASONIC_TRIG 16
+#define SIDE_ULTRASONIC_ECHO 17
 
 //A4
 #define LEFT_LINE_SENSE 36


### PR DESCRIPTION
Some updates to the library for C-term. I'm hesitant to commit them - not sure if Kevin has similar changes in mind. Happy to do so, if you want. 

Unfortunately, as something of a github novice, there are four things in one pull request:

The first two commits are pin assignments for the new board. They need to be done before C-term, of course. Kevin has them, too -- here's a chance to compare notes.

The third commit ("made setEffort ramp a bit") is the most experimental. For non-closed-loop control, I added a "target effort" so that the current effort isn't changed so fast. It makes changes in effort ramp a bit to avoid slamming the motors. I've tested it and have been using it quite a bit. Note that it doesn't affect the closed-loop control -- that would need a completely different approach (which would be a nice addition). Still, if it's too risky, we can drop it. The motors would jerk more, but so be it.

The fourth commit adds an important line to setSpeed(). When switching from non-closed-loop to closed-loop, you can get racing motors. This line resets the current position when that switch is made. (And only when that switch is made.) I'd call it essential, since the scenario is a distinct possibility.

The last commit just adds a quick servo example so they can test that independently of everything else.

